### PR TITLE
Allow trait-based dynamic crypto implementations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ece"
-version = "1.0.1"
+version = "1.1.0"
 authors = ["Edouard Oger <eoger@fastmail.com>", "JR Conlin <jrconlin@gmail.com>"]
 license = "MPL-2.0"
 edition = "2018"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ failure_derive = "0.1"
 base64 = "0.10"
 hkdf = { version = "0.7", optional = true }
 lazy_static = { version = "1.2", optional = true }
+once_cell = "0.2.6"
 openssl = { version = "0.10", optional = true }
 serde = { version = "1.0.91", features = ["derive"], optional = true }
 sha2 = { version = "0.8", optional = true }

--- a/src/crypto/holder.rs
+++ b/src/crypto/holder.rs
@@ -1,0 +1,51 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use super::Cryptographer;
+use failure::Fail;
+use once_cell::sync::OnceCell;
+
+static CRYPTOGRAPHER: OnceCell<&'static dyn Cryptographer> = OnceCell::new();
+
+#[derive(Debug, Fail)]
+#[fail(display = "Cryptographer already initialized")]
+pub struct SetCryptographerError(());
+
+/// Sets the global object that will be used for cryptographic operations.
+///
+/// This is a convenience wrapper over [`set_cryptographer`],
+/// but takes a `Box<dyn Cryptographer>` instead.
+#[cfg(not(feature = "backend-openssl"))]
+pub fn set_boxed_cryptographer(c: Box<dyn Cryptographer>) -> Result<(), SetCryptographerError> {
+    // Just leak the Box. It wouldn't be freed as a `static` anyway, and we
+    // never allow this to be re-assigned (so it's not a meaningful memory leak).
+    set_cryptographer(Box::leak(c))
+}
+
+/// Sets the global object that will be used for cryptographic operations.
+///
+/// This function may only be called once in the lifetime of a program.
+///
+/// Any calls into this crate that perform cryptography prior to calling this
+/// function will panic.
+pub fn set_cryptographer(c: &'static dyn Cryptographer) -> Result<(), SetCryptographerError> {
+    CRYPTOGRAPHER.set(c).map_err(|_| SetCryptographerError(()))
+}
+
+pub(crate) fn get_cryptographer() -> &'static dyn Cryptographer {
+    autoinit_crypto();
+    *CRYPTOGRAPHER
+        .get()
+        .expect("`rust-ece` cryptographer not initialized!")
+}
+
+#[cfg(feature = "backend-openssl")]
+#[inline]
+fn autoinit_crypto() {
+    let _ = set_cryptographer(&super::openssl::OpensslCryptographer);
+}
+
+#[cfg(not(feature = "backend-openssl"))]
+#[inline]
+fn autoinit_crypto() {}

--- a/src/crypto/openssl.rs
+++ b/src/crypto/openssl.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use crate::{
-    crypto_backend::{Crypto, EcKeyComponents, LocalKeyPair, RemotePublicKey},
+    crypto::{Cryptographer, EcKeyComponents, LocalKeyPair, RemotePublicKey},
     error::*,
 };
 use hkdf::Hkdf;
@@ -18,11 +18,12 @@ use openssl::{
     symm::{Cipher, Crypter, Mode},
 };
 use sha2::Sha256;
-use std::fmt;
+use std::{any::Any, fmt};
 
 lazy_static! {
     static ref GROUP_P256: EcGroup = EcGroup::from_curve_name(Nid::X9_62_PRIME256V1).unwrap();
 }
+const AES_GCM_TAG_LENGTH: usize = 16;
 
 #[derive(Clone, Debug)]
 pub struct OpenSSLRemotePublicKey {
@@ -30,6 +31,12 @@ pub struct OpenSSLRemotePublicKey {
 }
 
 impl OpenSSLRemotePublicKey {
+    fn from_raw(raw: &[u8]) -> Result<Self> {
+        Ok(OpenSSLRemotePublicKey {
+            raw_pub_key: raw.to_vec(),
+        })
+    }
+
     fn to_pkey(&self) -> Result<PKey<Public>> {
         let mut bn_ctx = BigNumContext::new()?;
         let point = EcPoint::from_bytes(&GROUP_P256, &self.raw_pub_key, &mut bn_ctx)?;
@@ -39,14 +46,11 @@ impl OpenSSLRemotePublicKey {
 }
 
 impl RemotePublicKey for OpenSSLRemotePublicKey {
-    fn from_raw(raw: &[u8]) -> Result<Self> {
-        Ok(OpenSSLRemotePublicKey {
-            raw_pub_key: raw.to_vec(),
-        })
-    }
-
     fn as_raw(&self) -> Result<Vec<u8>> {
         Ok(self.raw_pub_key.to_vec())
+    }
+    fn as_any(&self) -> &dyn Any {
+        self
     }
 }
 
@@ -56,7 +60,7 @@ pub struct OpenSSLLocalKeyPair {
 }
 
 impl fmt::Debug for OpenSSLLocalKeyPair {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "{:?}",
@@ -66,26 +70,14 @@ impl fmt::Debug for OpenSSLLocalKeyPair {
 }
 
 impl OpenSSLLocalKeyPair {
-    fn to_pkey(&self) -> Result<PKey<Private>> {
-        PKey::from_ec_key(self.ec_key.clone()).map_err(std::convert::Into::into)
-    }
-}
-
-impl LocalKeyPair for OpenSSLLocalKeyPair {
     /// Generate a random local key pair using OpenSSL `ECKey::generate`.
     fn generate_random() -> Result<Self> {
         let ec_key = EcKey::generate(&GROUP_P256)?;
         Ok(OpenSSLLocalKeyPair { ec_key })
     }
 
-    /// Export the public key component in the binary uncompressed point representation
-    /// using OpenSSL `PointConversionForm::UNCOMPRESSED`.
-    fn pub_as_raw(&self) -> Result<Vec<u8>> {
-        let pub_key_point = self.ec_key.public_key();
-        let mut bn_ctx = BigNumContext::new()?;
-        let uncompressed =
-            pub_key_point.to_bytes(&GROUP_P256, PointConversionForm::UNCOMPRESSED, &mut bn_ctx)?;
-        Ok(uncompressed)
+    fn to_pkey(&self) -> Result<PKey<Private>> {
+        PKey::from_ec_key(self.ec_key.clone()).map_err(std::convert::Into::into)
     }
 
     fn from_raw_components(components: &EcKeyComponents) -> Result<Self> {
@@ -101,6 +93,18 @@ impl LocalKeyPair for OpenSSLLocalKeyPair {
             ec_key: private_key,
         })
     }
+}
+
+impl LocalKeyPair for OpenSSLLocalKeyPair {
+    /// Export the public key component in the binary uncompressed point representation
+    /// using OpenSSL `PointConversionForm::UNCOMPRESSED`.
+    fn pub_as_raw(&self) -> Result<Vec<u8>> {
+        let pub_key_point = self.ec_key.public_key();
+        let mut bn_ctx = BigNumContext::new()?;
+        let uncompressed =
+            pub_key_point.to_bytes(&GROUP_P256, PointConversionForm::UNCOMPRESSED, &mut bn_ctx)?;
+        Ok(uncompressed)
+    }
 
     fn raw_components(&self) -> Result<(EcKeyComponents)> {
         let private_key = self.ec_key.private_key();
@@ -108,6 +112,10 @@ impl LocalKeyPair for OpenSSLLocalKeyPair {
             private_key.to_vec(),
             self.pub_as_raw()?,
         ))
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
     }
 }
 
@@ -117,20 +125,32 @@ impl From<EcKey<Private>> for OpenSSLLocalKeyPair {
     }
 }
 
-pub struct OpenSSLCrypto;
-impl Crypto for OpenSSLCrypto {
-    type RemotePublicKey = OpenSSLRemotePublicKey;
-    type LocalKeyPair = OpenSSLLocalKeyPair;
+pub struct OpensslCryptographer;
+impl Cryptographer for OpensslCryptographer {
+    fn generate_ephemeral_keypair(&self) -> Result<Box<dyn LocalKeyPair>> {
+        Ok(Box::new(OpenSSLLocalKeyPair::generate_random()?))
+    }
 
-    fn generate_ephemeral_keypair() -> Result<Self::LocalKeyPair> {
-        Self::LocalKeyPair::generate_random()
+    fn import_key_pair(&self, components: &EcKeyComponents) -> Result<Box<dyn LocalKeyPair>> {
+        Ok(Box::new(OpenSSLLocalKeyPair::from_raw_components(
+            components,
+        )?))
+    }
+
+    fn import_public_key(&self, raw: &[u8]) -> Result<Box<dyn RemotePublicKey>> {
+        Ok(Box::new(OpenSSLRemotePublicKey::from_raw(raw)?))
     }
 
     fn compute_ecdh_secret(
-        remote: &Self::RemotePublicKey,
-        local: &Self::LocalKeyPair,
+        &self,
+        remote: &dyn RemotePublicKey,
+        local: &dyn LocalKeyPair,
     ) -> Result<Vec<u8>> {
+        let local_any = local.as_any();
+        let local = local_any.downcast_ref::<OpenSSLLocalKeyPair>().unwrap();
         let private = local.to_pkey()?;
+        let remote_any = remote.as_any();
+        let remote = remote_any.downcast_ref::<OpenSSLRemotePublicKey>().unwrap();
         let public = remote.to_pkey()?;
         let mut deriver = Deriver::new(&private)?;
         deriver.set_peer(&public)?;
@@ -138,38 +158,46 @@ impl Crypto for OpenSSLCrypto {
         Ok(shared_key)
     }
 
-    fn hkdf_sha256(salt: &[u8], secret: &[u8], info: &[u8], len: usize) -> Result<Vec<u8>> {
+    fn hkdf_sha256(&self, salt: &[u8], secret: &[u8], info: &[u8], len: usize) -> Result<Vec<u8>> {
         let hk = Hkdf::<Sha256>::extract(Some(&salt[..]), &secret);
         let mut okm = vec![0u8; len];
         hk.expand(&info, &mut okm).unwrap();
         Ok(okm)
     }
 
-    fn aes_gcm_128_encrypt(key: &[u8], iv: &[u8], data: &[u8], tag_len: usize) -> Result<Vec<u8>> {
+    fn aes_gcm_128_encrypt(&self, key: &[u8], iv: &[u8], data: &[u8]) -> Result<Vec<u8>> {
         let cipher = Cipher::aes_128_gcm();
         let mut c = Crypter::new(cipher, Mode::Encrypt, key, Some(iv))?;
         let mut out = vec![0u8; data.len() + cipher.block_size()];
         let count = c.update(data, &mut out)?;
         let rest = c.finalize(&mut out[count..])?;
-        let mut tag = vec![0u8; tag_len];
+        let mut tag = vec![0u8; AES_GCM_TAG_LENGTH];
         c.get_tag(&mut tag)?;
         out.truncate(count + rest);
         out.append(&mut tag);
         Ok(out)
     }
 
-    fn aes_gcm_128_decrypt(key: &[u8], iv: &[u8], data: &[u8], tag: &[u8]) -> Result<Vec<u8>> {
+    fn aes_gcm_128_decrypt(
+        &self,
+        key: &[u8],
+        iv: &[u8],
+        ciphertext_and_tag: &[u8],
+    ) -> Result<Vec<u8>> {
+        let block_len = ciphertext_and_tag.len() - AES_GCM_TAG_LENGTH;
+        let ciphertext = &ciphertext_and_tag[0..block_len];
+        let tag = &ciphertext_and_tag[block_len..];
         let cipher = Cipher::aes_128_gcm();
         let mut c = Crypter::new(cipher, Mode::Decrypt, key, Some(iv))?;
-        let mut out = vec![0u8; data.len() + cipher.block_size()];
-        let count = c.update(data, &mut out)?;
+        let mut out = vec![0u8; ciphertext.len() + cipher.block_size()];
+        let count = c.update(ciphertext, &mut out)?;
         c.set_tag(tag)?;
         let rest = c.finalize(&mut out[count..])?;
         out.truncate(count + rest);
         Ok(out)
     }
 
-    fn random(dest: &mut [u8]) -> Result<()> {
+    fn random_bytes(&self, dest: &mut [u8]) -> Result<()> {
         Ok(rand_bytes(dest)?)
     }
 }

--- a/src/crypto_backends/mod.rs
+++ b/src/crypto_backends/mod.rs
@@ -1,8 +1,0 @@
-#[cfg(feature = "backend-openssl")]
-pub use self::openssl::{
-    OpenSSLCrypto as CryptoImpl, OpenSSLLocalKeyPair as LocalKeyPairImpl,
-    OpenSSLRemotePublicKey as RemotePublicKeyImpl,
-};
-
-#[cfg(feature = "backend-openssl")]
-pub mod openssl;

--- a/src/error.rs
+++ b/src/error.rs
@@ -12,7 +12,7 @@ pub struct Error(Box<Context<ErrorKind>>);
 
 impl Fail for Error {
     #[inline]
-    fn cause(&self) -> Option<&Fail> {
+    fn cause(&self) -> Option<&dyn Fail> {
         self.0.cause()
     }
 
@@ -24,7 +24,7 @@ impl Fail for Error {
 
 impl fmt::Display for Error {
     #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(&*self.0, f)
     }
 }
@@ -103,6 +103,7 @@ impl From<base64::DecodeError> for Error {
     }
 }
 
+#[cfg(feature = "backend-openssl")]
 macro_rules! impl_from_error {
     ($(($variant:ident, $type:ty)),+) => ($(
         impl From<$type> for ErrorKind {


### PR DESCRIPTION
This is more or less what @thomcc did in https://github.com/taskcluster/rust-hawk/pull/23 and should enable us to use rust-ece without pulling openssl at all in application-services.