### PR TITLE
Update to latest version of once_cell

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ failure_derive = "0.1"
 base64 = "0.10"
 hkdf = { version = "0.7", optional = true }
 lazy_static = { version = "1.2", optional = true }
-once_cell = "0.2.6"
+once_cell = "1.0.0"
 openssl = { version = "0.10", optional = true }
 serde = { version = "1.0.91", features = ["derive"], optional = true }
 sha2 = { version = "0.8", optional = true }


### PR DESCRIPTION
To avoid https://rustsec.org/advisories/RUSTSEC-2019-0017.html