### PR TITLE
Bump base64 version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,12 @@ keywords = ["http-ece", "web-push"]
 byteorder = "1.3"
 failure = "0.1"
 failure_derive = "0.1"
-base64 = "0.10"
+base64 = "0.12"
 hkdf = { version = "0.7", optional = true }
 lazy_static = { version = "1.2", optional = true }
-once_cell = "1.0.0"
+once_cell = "1.0"
 openssl = { version = "0.10", optional = true }
-serde = { version = "1.0.91", features = ["derive"], optional = true }
+serde = { version = "1.0", features = ["derive"], optional = true }
 sha2 = { version = "0.8", optional = true }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ece"
-version = "1.1.1"
+version = "1.1.2"
 authors = ["Edouard Oger <eoger@fastmail.com>", "JR Conlin <jrconlin@gmail.com>"]
 license = "MPL-2.0"
 edition = "2018"

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -25,7 +25,7 @@ pub trait LocalKeyPair: Send + Sync + 'static {
     /// binary uncompressed point representation.
     fn pub_as_raw(&self) -> Result<Vec<u8>>;
     /// Export the raw components of the keypair.
-    fn raw_components(&self) -> Result<(EcKeyComponents)>;
+    fn raw_components(&self) -> Result<EcKeyComponents>;
     /// For downcasting purposes.
     fn as_any(&self) -> &dyn Any;
 }

--- a/src/crypto/openssl.rs
+++ b/src/crypto/openssl.rs
@@ -106,7 +106,7 @@ impl LocalKeyPair for OpenSSLLocalKeyPair {
         Ok(uncompressed)
     }
 
-    fn raw_components(&self) -> Result<(EcKeyComponents)> {
+    fn raw_components(&self) -> Result<EcKeyComponents> {
         let private_key = self.ec_key.private_key();
         Ok(EcKeyComponents::new(
             private_key.to_vec(),


### PR DESCRIPTION
So we don't vendor 3 different `base64` in mozilla-central 😅 