### PR TITLE
replace failure with thiserror and backtrace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,8 @@ keywords = ["http-ece", "web-push"]
 
 [dependencies]
 byteorder = "1.3"
-failure = "0.1"
-failure_derive = "0.1"
+thiserror = "1.0"
+backtrace = "0.3"
 base64 = "0.12"
 hkdf = { version = "0.7", optional = true }
 lazy_static = { version = "1.2", optional = true }

--- a/src/crypto/holder.rs
+++ b/src/crypto/holder.rs
@@ -3,13 +3,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use super::Cryptographer;
-use failure::Fail;
 use once_cell::sync::OnceCell;
 
 static CRYPTOGRAPHER: OnceCell<&'static dyn Cryptographer> = OnceCell::new();
 
-#[derive(Debug, Fail)]
-#[fail(display = "Cryptographer already initialized")]
+#[derive(Debug, thiserror::Error)]
+#[error("Cryptographer already initialized")]
 pub struct SetCryptographerError(());
 
 /// Sets the global object that will be used for cryptographic operations.


### PR DESCRIPTION
Hello team!
We are getting rid of the failure crate in [application-services](https://github.com/mozilla/application-services/pull/3132) since [failure](https://github.com/rust-lang-nursery/failure) is deprecated, and moving our components to use [thiserror](https://github.com/dtolnay/thiserror) instead. 

The fxa-client component consumes this crate, so this pull request replaces failure with thiserror.

Ran `cargo test`, `cargo fmt` and `cargo clippy` before making this pull-request

Let me know what you think!