### PR TITLE
Removes backtracing and extra wrappers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ keywords = ["http-ece", "web-push"]
 [dependencies]
 byteorder = "1.3"
 thiserror = "1.0"
-backtrace = "0.3"
 base64 = "0.12"
 hkdf = { version = "0.7", optional = true }
 lazy_static = { version = "1.2", optional = true }

--- a/src/aesgcm.rs
+++ b/src/aesgcm.rs
@@ -221,7 +221,7 @@ fn encode_keys(raw_key1: &[u8], raw_key2: &[u8]) -> Result<Vec<u8>> {
     let mut combined = vec![0u8; ECE_WEBPUSH_AESGCM_KEYPAIR_LENGTH];
 
     if raw_key1.len() > ECE_WEBPUSH_RAW_KEY_LENGTH || raw_key2.len() > ECE_WEBPUSH_RAW_KEY_LENGTH {
-        return Err(ErrorKind::InvalidKeyLength.into());
+        return Err(Error::InvalidKeyLength);
     }
     // length prefix each key
     combined[0] = 0;

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,68 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use backtrace::Backtrace;
-use std::{boxed::Box, fmt, result};
-
-struct Context<T: fmt::Display + Sync + 'static> {
-    context: T,
-    backtrace: Backtrace,
-}
-
-impl<T: fmt::Display + Send + Sync + 'static> Context<T> {
-    pub fn new(context: T) -> Self {
-        Context {
-            context,
-            backtrace: Backtrace::new(),
-        }
-    }
-
-    pub fn get_context(&self) -> &T {
-        &self.context
-    }
-}
-
-impl<D: fmt::Display + Send + Sync + 'static> fmt::Debug for Context<D> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}\n\n{}", self.backtrace, self.context)
-    }
-}
-
-pub type Result<T> = result::Result<T, Error>;
+pub type Result<T> = std::result::Result<T, Error>;
 
 #[derive(Debug, thiserror::Error)]
-pub struct Error(Box<Context<ErrorKind>>);
-
-impl fmt::Display for Error {
-    #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Display::fmt(&*self.0.get_context(), f)
-    }
-}
-
-impl Error {
-    #[inline]
-    pub fn kind(&self) -> &ErrorKind {
-        &*self.0.get_context()
-    }
-}
-
-impl From<ErrorKind> for Error {
-    #[inline]
-    fn from(kind: ErrorKind) -> Error {
-        Error(Box::new(Context::new(kind)))
-    }
-}
-
-impl From<Context<ErrorKind>> for Error {
-    #[inline]
-    fn from(inner: Context<ErrorKind>) -> Error {
-        Error(Box::new(inner))
-    }
-}
-
-#[derive(Debug, thiserror::Error)]
-pub enum ErrorKind {
+pub enum Error {
     #[error("Invalid auth secret")]
     InvalidAuthSecret,
 
@@ -111,23 +53,6 @@ pub enum ErrorKind {
 impl From<base64::DecodeError> for Error {
     #[inline]
     fn from(_: base64::DecodeError) -> Error {
-        ErrorKind::DecodeError.into()
+        Error::DecodeError
     }
-}
-
-#[cfg(feature = "backend-openssl")]
-macro_rules! impl_from_error {
-    ($(($variant:ident, $type:ty)),+) => ($(
-        impl From<$type> for Error {
-            #[inline]
-            fn from(e: $type) -> Error {
-                ErrorKind::from(e).into()
-            }
-        }
-    )*);
-}
-
-#[cfg(feature = "backend-openssl")]
-impl_from_error! {
-    (OpenSSLError, ::openssl::error::ErrorStack)
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -40,7 +40,7 @@ pub enum Error {
     EncryptPadding,
 
     #[error("Could not decode base64 entry")]
-    DecodeError,
+    DecodeError(#[from] base64::DecodeError),
 
     #[error("Crypto backend error")]
     CryptoError,
@@ -48,11 +48,4 @@ pub enum Error {
     #[cfg(feature = "backend-openssl")]
     #[error("OpenSSL error: {0}")]
     OpenSSLError(#[from] openssl::error::ErrorStack),
-}
-
-impl From<base64::DecodeError> for Error {
-    #[inline]
-    fn from(_: base64::DecodeError) -> Error {
-        Error::DecodeError
-    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -264,8 +264,8 @@ mod aes128gcm_tests {
             "45b74d2b69be9b074de3b35aa87e7c15611d",
         )
         .unwrap_err();
-        match err.kind() {
-            ErrorKind::HeaderTooShort => {}
+        match err {
+            Error::HeaderTooShort => {}
             _ => unreachable!(),
         };
     }
@@ -279,8 +279,8 @@ mod aes128gcm_tests {
             "de5b696b87f1a15cb6adebdd79d6f99e000000120100b6bc1826c37c9f73dd6b4859c2b505181952",
         )
         .unwrap_err();
-        match err.kind() {
-            ErrorKind::InvalidKeyLength => {}
+        match err {
+            Error::InvalidKeyLength => {}
             _ => unreachable!(),
         };
     }
@@ -293,8 +293,8 @@ mod aes128gcm_tests {
             "355a38cd6d9bef15990e2d3308dbd600",
             "8115f4988b8c392a7bacb43c8f1ac5650000001241041994483c541e9bc39a6af03ff713aa7745c284e138a42a2435b797b20c4b698cf5118b4f8555317c190eabebfab749c164d3f6bdebe0d441719131a357d8890a13c4dbd4b16ff3dd5a83f7c91ad6e040ac42730a7f0b3cd3245e9f8d6ff31c751d410cfd"
         ).unwrap_err();
-        match err.kind() {
-            ErrorKind::OpenSSLError(_) => {}
+        match err {
+            Error::OpenSSLError(_) => {}
             _ => unreachable!(),
         };
     }
@@ -307,8 +307,8 @@ mod aes128gcm_tests {
             "40c241fde4269ee1e6d725592d982718",
             "dbe215507d1ad3d2eaeabeae6e874d8f0000001241047bc4343f34a8348cdc4e462ffc7c40aa6a8c61a739c4c41d45125505f70e9fc5f9efa86852dd488dcf8e8ea2cafb75e07abd5ee7c9d5c038bafef079571b0bda294411ce98c76dd031c0e580577a4980a375e45ed30429be0e2ee9da7e6df8696d01b8ec"
         ).unwrap_err();
-        match err.kind() {
-            ErrorKind::DecryptPadding => {}
+        match err {
+            Error::DecryptPadding => {}
             _ => unreachable!(),
         };
     }


### PR DESCRIPTION
Follow up to #40 and #42 

Cleans up the error handling in the crate. 
Removes the unnecessary backtracing and wrappers. Namely simplifies the ErrorKind and Error to just Error and gets rid of the Context wrapper and backtrace, getting rid of all the unnecessary From impls and into() and kind() calls.

Let me know what you think and if I missed something 🙏 

Ran `cargo test`, `cargo fmt` and `cargo clippy` before opening.

