### PR TITLE
Prepare release v1.2.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ece"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["Edouard Oger <eoger@fastmail.com>", "JR Conlin <jrconlin@gmail.com>"]
 license = "MPL-2.0"
 edition = "2018"
@@ -12,12 +12,12 @@ keywords = ["http-ece", "web-push"]
 byteorder = "1.3"
 thiserror = "1.0"
 base64 = "0.12"
-hkdf = { version = "0.8", optional = true }
+hkdf = { version = "0.9", optional = true }
 lazy_static = { version = "1.4", optional = true }
 once_cell = "1.4"
 openssl = { version = "0.10", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
-sha2 = { version = "0.8", optional = true }
+sha2 = { version = "0.9", optional = true }
 
 [dev-dependencies]
 hex = "0.4"

--- a/src/aesgcm.rs
+++ b/src/aesgcm.rs
@@ -186,7 +186,7 @@ impl EceWebPush for AesGcmEceWebPush {
         if padding_size >= block.len() - 2 {
             return Err(Error::DecryptPadding);
         }
-        if block[2..(2+padding_size)].iter().any(|b| *b != 0u8) {
+        if block[2..(2 + padding_size)].iter().any(|b| *b != 0u8) {
             return Err(Error::DecryptPadding);
         }
         Ok(&block[(2 + padding_size)..])

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -395,11 +395,16 @@ mod aesgcm_tests {
 
         let result = try_decrypt(priv_key_raw, pub_key_raw, auth_raw, &block).unwrap();
 
-        println!("Result: b64={}", base64::encode_config(&result, base64::URL_SAFE_NO_PAD));
-        println!("Plaintext: b64={}", base64::encode_config(&plaintext, base64::URL_SAFE_NO_PAD));
+        println!(
+            "Result: b64={}",
+            base64::encode_config(&result, base64::URL_SAFE_NO_PAD)
+        );
+        println!(
+            "Plaintext: b64={}",
+            base64::encode_config(&plaintext, base64::URL_SAFE_NO_PAD)
+        );
         assert!(result == plaintext)
     }
-
 
     #[test]
     fn test_e2e() {


### PR DESCRIPTION
This includes a fix for padding in the legacy aesgcm mode, and some opportunistic dependency updates.