### PR TITLE
Add top-level access to AesGcm encoding scheme

### DIFF
--- a/src/aes128gcm.rs
+++ b/src/aes128gcm.rs
@@ -26,6 +26,9 @@ const ECE_AES128GCM_NONCE_INFO: &str = "Content-Encoding: nonce\0";
 // TODO: When done, remove the aes128gcm prefixes and the EC_ ones.
 // As for now it makes it easier to Ctrl + F into ecec :)
 
+/// Web Push encryption structure for the AES128GCM encoding scheme ([RFC8591](https://tools.ietf.org/html/rfc8291))
+/// 
+/// This structure is meant for advanced use. For simple encryption/decryption, use the top-level [`encrypt`](crate::encrypt) and [`decrypt`](crate::decrypt) functions.
 pub struct Aes128GcmEceWebPush;
 impl Aes128GcmEceWebPush {
     /// Encrypts a Web Push message using the "aes128gcm" scheme. This function

--- a/src/aesgcm.rs
+++ b/src/aesgcm.rs
@@ -119,7 +119,9 @@ impl AesGcmEceWebPush {
         params: WebPushParams,
     ) -> Result<AesGcmEncryptedBlock> {
         let cryptographer = crypto::holder::get_cryptographer();
-        let salt = if let Some(salt) = params.salt {salt} else {
+        let salt = if let Some(salt) = params.salt {
+            salt
+        } else {
             let mut salt = [0u8; ECE_SALT_LENGTH];
             cryptographer.random_bytes(&mut salt)?;
             salt.to_vec()

--- a/src/aesgcm.rs
+++ b/src/aesgcm.rs
@@ -119,7 +119,7 @@ impl AesGcmEceWebPush {
         params: WebPushParams,
     ) -> Result<AesGcmEncryptedBlock> {
         let cryptographer = crypto::holder::get_cryptographer();
-        let salt = {
+        let salt = if let Some(salt) = params.salt {salt} else {
             let mut salt = [0u8; ECE_SALT_LENGTH];
             cryptographer.random_bytes(&mut salt)?;
             salt.to_vec()

--- a/src/aesgcm.rs
+++ b/src/aesgcm.rs
@@ -87,7 +87,9 @@ impl AesGcmEncryptedBlock {
         base64::encode_config(&self.ciphertext, base64::URL_SAFE_NO_PAD)
     }
 }
-
+/// Web Push encryption structure for the legacy AESGCM encoding scheme ([Web Push Encryption Draft 4](https://tools.ietf.org/html/draft-ietf-webpush-encryption-04))
+/// 
+/// This structure is meant for advanced use. For simple encryption/decryption, use the top-level [`encrypt_aesgcm`](crate::legacy::encrypt_aesgcm) and [`decrypt_aesgcm`](crate::legacy::decrypt_aesgcm) functions.
 pub struct AesGcmEceWebPush;
 impl AesGcmEceWebPush {
     /// Encrypts a Web Push message using the "aesgcm" scheme. This function

--- a/src/legacy.rs
+++ b/src/legacy.rs
@@ -92,10 +92,10 @@ mod aesgcm_tests {
             params,
         )?;
         Ok(AesGcmTestPayload {
-            dh : hex::encode(encrypted_block.dh),
-            salt : hex::encode(encrypted_block.salt),
-            rs : encrypted_block.rs,
-            ciphertext : hex::encode(encrypted_block.ciphertext),
+            dh: hex::encode(encrypted_block.dh),
+            salt: hex::encode(encrypted_block.salt),
+            rs: encrypted_block.rs,
+            ciphertext: hex::encode(encrypted_block.ciphertext),
         })
     }
 
@@ -170,7 +170,10 @@ mod aesgcm_tests {
             4096,
             "I am the walrus",
         ).unwrap();
-        println!("Result {:?}",encrypted_block);
-        assert_eq!(encrypted_block.ciphertext, "ea7a80414304f2136ac39277925f1ca55549ca55ca62a64e7ac7991bc52e78aa40");
+        println!("Result {:?}", encrypted_block);
+        assert_eq!(
+            encrypted_block.ciphertext,
+            "ea7a80414304f2136ac39277925f1ca55549ca55ca62a64e7ac7991bc52e78aa40"
+        );
     }
 }

--- a/src/legacy.rs
+++ b/src/legacy.rs
@@ -1,0 +1,176 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use crate::{
+    aesgcm::{AesGcmEceWebPush, AesGcmEncryptedBlock},
+    common::WebPushParams,
+    crypto::EcKeyComponents,
+    error::*,
+};
+
+/// Encrypt a block using legacy AESGCM encoding.
+///
+/// param remote_pub &[u8] - The remote public key
+/// param remote_auth &u8 - The remote authorization token
+/// param salt &[u8] - The locally generated random salt
+/// param data &[u8] - The data to encrypt
+///
+pub fn encrypt_aesgcm(
+    remote_pub: &[u8],
+    remote_auth: &[u8],
+    salt: &[u8],
+    data: &[u8],
+) -> Result<AesGcmEncryptedBlock> {
+    let cryptographer = crate::crypto::holder::get_cryptographer();
+    let remote_key = cryptographer.import_public_key(remote_pub)?;
+    let local_key_pair = cryptographer.generate_ephemeral_keypair()?;
+    let mut padr = [0u8; 2];
+    cryptographer.random_bytes(&mut padr)?;
+    // since it's a sampled random, endian doesn't really matter.
+    let pad = ((usize::from(padr[0]) + (usize::from(padr[1]) << 8)) % 4095) + 1;
+    let params = WebPushParams::new(4096, pad, Vec::from(salt));
+    AesGcmEceWebPush::encrypt_with_keys(&*local_key_pair, &*remote_key, &remote_auth, data, params)
+}
+
+/// Decrypt a block using legacy AESGCM encoding.
+///
+/// param components &str - The locally generated private key components.
+/// param auth &str - The locally generated auth token (this value was shared with the encryptor)
+/// param data &[u8] - The encrypted data block
+///
+pub fn decrypt_aesgcm(
+    components: &EcKeyComponents,
+    auth: &[u8],
+    data: &AesGcmEncryptedBlock,
+) -> Result<Vec<u8>> {
+    let cryptographer = crate::crypto::holder::get_cryptographer();
+    let priv_key = cryptographer.import_key_pair(components).unwrap();
+    AesGcmEceWebPush::decrypt(&*priv_key, &auth, data)
+}
+
+#[cfg(all(test, feature = "backend-openssl"))]
+mod aesgcm_tests {
+    use super::*;
+    use hex;
+
+    #[derive(Debug)]
+    struct AesGcmTestPayload {
+        dh: String,
+        salt: String,
+        rs: u32,
+        ciphertext: String,
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn try_encrypt(
+        private_key: &str,
+        public_key: &str,
+        remote_pub_key: &str,
+        auth_secret: &str,
+        salt: &str,
+        pad_length: usize,
+        rs: u32,
+        plaintext: &str,
+    ) -> Result<AesGcmTestPayload> {
+        let cryptographer = crate::crypto::holder::get_cryptographer();
+        let private_key = hex::decode(private_key).unwrap();
+        let public_key = hex::decode(public_key).unwrap();
+        let ec_key = EcKeyComponents::new(private_key, public_key);
+        let local_key_pair = cryptographer.import_key_pair(&ec_key)?;
+        let remote_pub_key = hex::decode(remote_pub_key).unwrap();
+        let remote_pub_key = cryptographer.import_public_key(&remote_pub_key).unwrap();
+        let auth_secret = hex::decode(auth_secret).unwrap();
+        let salt = hex::decode(salt).unwrap();
+        let plaintext = plaintext.as_bytes();
+        let params = WebPushParams::new(rs, pad_length, salt);
+        let encrypted_block = AesGcmEceWebPush::encrypt_with_keys(
+            &*local_key_pair,
+            &*remote_pub_key,
+            &auth_secret,
+            &plaintext,
+            params,
+        )?;
+        Ok(AesGcmTestPayload {
+            dh : hex::encode(encrypted_block.dh),
+            salt : hex::encode(encrypted_block.salt),
+            rs : encrypted_block.rs,
+            ciphertext : hex::encode(encrypted_block.ciphertext),
+        })
+    }
+
+    fn try_decrypt(
+        private_key: &str,
+        public_key: &str,
+        auth_secret: &str,
+        payload: &AesGcmTestPayload,
+    ) -> Result<String> {
+        let private_key = hex::decode(private_key).unwrap();
+        let public_key = hex::decode(public_key).unwrap();
+        let ec_key = EcKeyComponents::new(private_key, public_key);
+        let plaintext = decrypt_aesgcm(
+            &ec_key,
+            &hex::decode(auth_secret).unwrap(),
+            &AesGcmEncryptedBlock::new(
+                &hex::decode(&payload.dh).unwrap(),
+                &hex::decode(&payload.salt).unwrap(),
+                payload.rs,
+                hex::decode(&payload.ciphertext).unwrap(),
+            )?,
+        )?;
+        Ok(String::from_utf8(plaintext).unwrap())
+    }
+
+    #[test]
+    fn test_e2e() {
+        let (local_key, remote_key) = crate::generate_keys().unwrap();
+        let plaintext = b"There was a green mouse, running in the grass";
+        let mut auth_secret = vec![0u8; 16];
+        let cryptographer = crate::crypto::holder::get_cryptographer();
+        cryptographer.random_bytes(&mut auth_secret).unwrap();
+        let remote_public = cryptographer
+            .import_public_key(&remote_key.pub_as_raw().unwrap())
+            .unwrap();
+        let params = WebPushParams::default();
+        let encrypted_block = AesGcmEceWebPush::encrypt_with_keys(
+            &*local_key,
+            &*remote_public,
+            &auth_secret,
+            plaintext,
+            params,
+        )
+        .unwrap();
+        let decrypted =
+            AesGcmEceWebPush::decrypt(&*remote_key, &auth_secret, &encrypted_block).unwrap();
+        assert_eq!(decrypted, plaintext.to_vec());
+    }
+
+    #[test]
+    fn test_conv_fn() -> Result<()> {
+        let (local_key, auth) = crate::generate_keypair_and_auth_secret()?;
+        let plaintext = b"There was a little ship that had never sailed";
+        let mut salt = vec![0u8; 16];
+        let cryptographer = crate::crypto::holder::get_cryptographer();
+        cryptographer.random_bytes(&mut salt)?;
+        let encoded = encrypt_aesgcm(&local_key.pub_as_raw()?, &auth, &salt, plaintext).unwrap();
+        let decoded = decrypt_aesgcm(&local_key.raw_components()?, &auth, &encoded)?;
+        assert_eq!(decoded, plaintext.to_vec());
+        Ok(())
+    }
+
+    #[test]
+    fn try_encrypt_ietf_rfc() {
+        let encrypted_block = try_encrypt(
+            "9c249c7a4f90a448e638e953fab437f27673bdd3e5a9ad34672d22ea6d8e26f6",
+            "04da110db6fce091a6f20e59e42171bab4aab17589d7522d7d71166152c4f3963b0989038d7b0811ce1aab161a4351bc06a917089e833e90eb5ad7568ff9ae8075",
+            "042124063ccbf19dc2fa88b643ba04e6dd8da7ea7ba2c8c62e0f77a943f4c2fa914f6d44116c9fd1c40341c6a440cab3e2140a60e4378a5da735972de078005105",
+            "476f6f20676f6f206727206a6f6f6221",
+            "96781aadbc8a7cca22f59ef9c585e692",
+            0,
+            4096,
+            "I am the walrus",
+        ).unwrap();
+        println!("Result {:?}",encrypted_block);
+        assert_eq!(encrypted_block.ciphertext, "ea7a80414304f2136ac39277925f1ca55549ca55ca62a64e7ac7991bc52e78aa40");
+    }
+}

--- a/src/legacy.rs
+++ b/src/legacy.rs
@@ -11,10 +11,10 @@ use crate::{
 
 /// Encrypt a block using legacy AESGCM encoding.
 ///
-/// param remote_pub &[u8] - The remote public key
-/// param remote_auth &u8 - The remote authorization token
-/// param salt &[u8] - The locally generated random salt
-/// param data &[u8] - The data to encrypt
+/// * `remote_pub` : the remote public key
+/// * `remote_auth` : the remote authorization token
+/// * `salt &[u8]` : the locally generated random salt
+/// * `data &[u8]` : the data to encrypt
 ///
 pub fn encrypt_aesgcm(
     remote_pub: &[u8],
@@ -35,9 +35,9 @@ pub fn encrypt_aesgcm(
 
 /// Decrypt a block using legacy AESGCM encoding.
 ///
-/// param components &str - The locally generated private key components.
-/// param auth &str - The locally generated auth token (this value was shared with the encryptor)
-/// param data &[u8] - The encrypted data block
+/// * `components` : the locally generated private key components.
+/// * `auth` : the locally generated auth token (this value was shared with the encryptor).
+/// * `data` : the encrypted data block
 ///
 pub fn decrypt_aesgcm(
     components: &EcKeyComponents,
@@ -158,9 +158,9 @@ mod aesgcm_tests {
         Ok(())
     }
 
-    /// Test data from [IETF Web Push Encryption Draft 5](https://tools.ietf.org/html/draft-ietf-webpush-encryption-04#section-5)
     #[test]
     fn try_encrypt_ietf_rfc() {
+        // Test data from [IETF Web Push Encryption Draft 5](https://tools.ietf.org/html/draft-ietf-webpush-encryption-04#section-5)
         let encrypted_block = try_encrypt(
             "9c249c7a4f90a448e638e953fab437f27673bdd3e5a9ad34672d22ea6d8e26f6",
             "04da110db6fce091a6f20e59e42171bab4aab17589d7522d7d71166152c4f3963b0989038d7b0811ce1aab161a4351bc06a917089e833e90eb5ad7568ff9ae8075",
@@ -177,9 +177,10 @@ mod aesgcm_tests {
         );
     }
 
-    /// Test data from [IETF Web Push Encryption Draft 5](https://tools.ietf.org/html/draft-ietf-webpush-encryption-04#section-5)
+    
     #[test]
     fn test_decrypt_ietf_rfc() {
+        // Test data from [IETF Web Push Encryption Draft 5](https://tools.ietf.org/html/draft-ietf-webpush-encryption-04#section-5)
         let plaintext = try_decrypt(
             "f455a5d79fd05100160da0f7937979d19059409e1abb6ec5d55e05d2e2d20ff3",
             "042124063ccbf19dc2fa88b643ba04e6dd8da7ea7ba2c8c62e0f77a943f4c2fa914f6d44116c9fd1c40341c6a440cab3e2140a60e4378a5da735972de078005105",

--- a/src/legacy.rs
+++ b/src/legacy.rs
@@ -170,7 +170,6 @@ mod aesgcm_tests {
             4096,
             "I am the walrus",
         ).unwrap();
-        println!("Result {:?}", encrypted_block);
         assert_eq!(
             encrypted_block.ciphertext,
             "ea7a80414304f2136ac39277925f1ca55549ca55ca62a64e7ac7991bc52e78aa40"

--- a/src/legacy.rs
+++ b/src/legacy.rs
@@ -176,4 +176,20 @@ mod aesgcm_tests {
             "ea7a80414304f2136ac39277925f1ca55549ca55ca62a64e7ac7991bc52e78aa40"
         );
     }
+
+    #[test]
+    fn test_decrypt_ietf_rfc() {
+        let plaintext = try_decrypt(
+            "f455a5d79fd05100160da0f7937979d19059409e1abb6ec5d55e05d2e2d20ff3",
+            "042124063ccbf19dc2fa88b643ba04e6dd8da7ea7ba2c8c62e0f77a943f4c2fa914f6d44116c9fd1c40341c6a440cab3e2140a60e4378a5da735972de078005105",
+            "476f6f20676f6f206727206a6f6f6221",
+            &AesGcmTestPayload {
+                ciphertext : "ea7a80414304f2136ac39277925f1ca55549ca55ca62a64e7ac7991bc52e78aa40".to_owned(),
+                salt : "96781aadbc8a7cca22f59ef9c585e692".to_owned(),
+                dh : "04da110db6fce091a6f20e59e42171bab4aab17589d7522d7d71166152c4f3963b0989038d7b0811ce1aab161a4351bc06a917089e833e90eb5ad7568ff9ae8075".to_owned(),
+                rs : 4096,
+            }
+        ).unwrap();
+        assert_eq!(plaintext, "I am the walrus");
+    }
 }

--- a/src/legacy.rs
+++ b/src/legacy.rs
@@ -13,8 +13,8 @@ use crate::{
 ///
 /// * `remote_pub` : the remote public key
 /// * `remote_auth` : the remote authorization token
-/// * `salt &[u8]` : the locally generated random salt
-/// * `data &[u8]` : the data to encrypt
+/// * `salt` : the locally generated random salt
+/// * `data` : the data to encrypt
 ///
 pub fn encrypt_aesgcm(
     remote_pub: &[u8],

--- a/src/legacy.rs
+++ b/src/legacy.rs
@@ -158,6 +158,7 @@ mod aesgcm_tests {
         Ok(())
     }
 
+    /// Test data from [IETF Web Push Encryption Draft 5](https://tools.ietf.org/html/draft-ietf-webpush-encryption-04#section-5)
     #[test]
     fn try_encrypt_ietf_rfc() {
         let encrypted_block = try_encrypt(
@@ -176,6 +177,7 @@ mod aesgcm_tests {
         );
     }
 
+    /// Test data from [IETF Web Push Encryption Draft 5](https://tools.ietf.org/html/draft-ietf-webpush-encryption-04#section-5)
     #[test]
     fn test_decrypt_ietf_rfc() {
         let plaintext = try_decrypt(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -408,29 +408,6 @@ mod aesgcm_tests {
     }
 
     #[test]
-    fn test_e2e() {
-        let (local_key, remote_key) = generate_keys().unwrap();
-        let plaintext = b"When I grow up, I want to be a watermelon";
-        let mut auth_secret = vec![0u8; 16];
-        let cryptographer = crypto::holder::get_cryptographer();
-        cryptographer.random_bytes(&mut auth_secret).unwrap();
-        let remote_public = cryptographer
-            .import_public_key(&remote_key.pub_as_raw().unwrap())
-            .unwrap();
-        let params = WebPushParams::default();
-        let ciphertext = AesGcmEceWebPush::encrypt_with_keys(
-            &*local_key,
-            &*remote_public,
-            &auth_secret,
-            plaintext,
-            params,
-        )
-        .unwrap();
-        let decrypted = AesGcmEceWebPush::decrypt(&*remote_key, &auth_secret, &ciphertext).unwrap();
-        assert_eq!(decrypted, plaintext.to_vec());
-    }
-
-    #[test]
     fn test_keygen() {
         let cryptographer = crypto::holder::get_cryptographer();
         cryptographer.generate_ephemeral_keypair().unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,10 +30,10 @@ pub fn generate_keypair_and_auth_secret(
 
 /// Encrypt a block using default AES128GCM encoding.
 ///
-/// param remote_pub &[u8] - The remote public key
-/// param remote_auth &u8 - The remote authorization token
-/// param salt &[u8] - The locally generated random salt
-/// param data &[u8] - The data to encrypt
+/// * `remote_pub` : The remote public key
+/// * `remote_auth` : The remote authorization token
+/// * `salt` : The locally generated random salt
+/// * `data` : The data to encrypt
 ///
 pub fn encrypt(remote_pub: &[u8], remote_auth: &[u8], salt: &[u8], data: &[u8]) -> Result<Vec<u8>> {
     let cryptographer = crypto::holder::get_cryptographer();
@@ -55,9 +55,9 @@ pub fn encrypt(remote_pub: &[u8], remote_auth: &[u8], salt: &[u8], data: &[u8]) 
 
 /// Decrypt a block using default AES128GCM encoding.
 ///
-/// param components &str - The locally generated private key components.
-/// param auth &str - The locally generated auth token (this value was shared with the encryptor)
-/// param data &[u8] - The encrypted data block
+/// * `components` : The locally generated private key components.
+/// * `auth` : The locally generated auth token (this value was shared with the encryptor)
+/// * `data` : The encrypted data block
 ///
 pub fn decrypt(components: &EcKeyComponents, auth: &[u8], data: &[u8]) -> Result<Vec<u8>> {
     let cryptographer = crypto::holder::get_cryptographer();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ mod aesgcm;
 mod common;
 pub mod crypto;
 mod error;
+pub mod legacy;
 
 pub use crate::{
     aes128gcm::Aes128GcmEceWebPush,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@ pub fn generate_keypair_and_auth_secret(
 /// * `salt` : The locally generated random salt
 /// * `data` : The data to encrypt
 ///
+/// *For the legacy AESGCM version, go to* [`encrypt_aesgcm`](crate::legacy::encrypt_aesgcm)
 pub fn encrypt(remote_pub: &[u8], remote_auth: &[u8], salt: &[u8], data: &[u8]) -> Result<Vec<u8>> {
     let cryptographer = crypto::holder::get_cryptographer();
     let remote_key = cryptographer.import_public_key(remote_pub)?;
@@ -59,6 +60,7 @@ pub fn encrypt(remote_pub: &[u8], remote_auth: &[u8], salt: &[u8], data: &[u8]) 
 /// * `auth` : The locally generated auth token (this value was shared with the encryptor)
 /// * `data` : The encrypted data block
 ///
+/// *For the legacy AESGCM version, go to* [`decrypt_aesgcm`](crate::legacy::decrypt_aesgcm)
 pub fn decrypt(components: &EcKeyComponents, auth: &[u8], data: &[u8]) -> Result<Vec<u8>> {
     let cryptographer = crypto::holder::get_cryptographer();
     let priv_key = cryptographer.import_key_pair(components).unwrap();


### PR DESCRIPTION
As discussed in #35, the current API does not allow access to encryption and decryption functionality for the `AesGcm` legacy encoding scheme without implementing a new back-end, even though it *is* fully implemented for OpenSSL internally. 

This pull request provides an access to the AesGcm encoding scheme through top-level functions in a `legacy` module.

It tries to mimic the main `Aes128Gcm` top-level library structure and tests.

So far, 4 tests have been implemented, using the IETF example data from [IETF Web Push Encryption Draft 4](https://tools.ietf.org/html/draft-ietf-webpush-encryption-04#appendix-A), with no padding and an `rs` of 4096.

For this to work, a minor fix has been implemented in the `AesGcmEceWebPush::encrypt_with_keys` function to allow the use of the salt provided in the `params` argument, which was previously ignored and made the tests fail.

To finalize this pull request, it would be better to provide more tests but for the moment I am unsure of where to get or generate relevant test data.