### PR TITLE
New API for the `headers` function

### DIFF
--- a/src/aesgcm.rs
+++ b/src/aesgcm.rs
@@ -59,11 +59,11 @@ impl AesGcmEncryptedBlock {
     /// so it can be included in the `Crypto-Key` field.
     ///
     /// Disclaimer : You will need to manually add the Authorization field for VAPID containing the JSON Web Token
-    pub fn headers(&self, public_key: Option<&[u8]>) -> Vec<(&'static str, String)> {
+    pub fn headers(&self, vapid_public_key: Option<&[u8]>) -> Vec<(&'static str, String)> {
         let mut result = Vec::new();
         let mut rs = "".to_owned();
         let dh = base64::encode_config(&self.dh, base64::URL_SAFE_NO_PAD);
-        let crypto_key = match public_key {
+        let crypto_key = match vapid_public_key {
             Some(public_key) => format!(
                 "dh={}; p256ecdsa={}",
                 dh,

--- a/src/aesgcm.rs
+++ b/src/aesgcm.rs
@@ -65,7 +65,7 @@ impl AesGcmEncryptedBlock {
         let dh = base64::encode_config(&self.dh, base64::URL_SAFE_NO_PAD);
         let crypto_key = match public_key {
             Some(public_key) => format!(
-                "dh={}, p256ecdsa={}",
+                "dh={}; p256ecdsa={}",
                 dh,
                 base64::encode_config(public_key, base64::URL_SAFE_NO_PAD)
             ),


### PR DESCRIPTION
**This pull request addresses issue #50**

This new API ( ⚠️ breaking change) is meant to:

 - Avoid moving `self` into the function since it is not necessary (currently, it forces a copy if we want both the headers and the `ciphertext` because both require moving out of the `AesGcmEncryptedBlock`)
 - Avoid extra allocation by using `&'static str`s instead of `String`s for the keys
 - Avoid the use of `HashMap` that adds extra workload to the process
 - Add the possibility to automatically include the VAPID public key in the `Crypto-Key` header (thus removing the need to merge it, and allowing for the change from a `HashMap` to a `Vector`)

## Use cases

 - **The most common use case**: using both `headers` and `ciphertext` without having to copy one of them to avoid a double move
 - **Secondary use case**: Large user pools to send notifications to in one go. Since notification sending (and content encryption) is done per-browser, sending a simple notification to a lot of users can quickly multiply the amount of extra allocation and hashing done with `String` and `HashMap`. (e.g. 1 million users to notify individually in one go) Since the draft for the AESGCM scheme is not likely to change anymore and the AES128GCM scheme is handled separately, we can now assume keys for AESGCM headers will always be fixed and use `&'static str`s and a tuple `Vec` instead.