### PR TITLE
Pad to multiples of 128 bytes, rather than to a random length.

### DIFF
--- a/src/aes128gcm.rs
+++ b/src/aes128gcm.rs
@@ -14,7 +14,7 @@ const ECE_AES128GCM_HEADER_LENGTH: usize = 21;
 // The max AES128GCM Key ID Length is 255 octets. We use far less of that because we use
 // the "key_id" to store the exchanged public key since we don't cache the key_ids.
 // Code fails if the key_id is not a public key length field.
-const ECE_AES128GCM_PAD_SIZE: usize = 1;
+pub(crate) const ECE_AES128GCM_PAD_SIZE: usize = 1;
 
 const ECE_WEBPUSH_AES128GCM_IKM_INFO_PREFIX: &str = "WebPush: info\0";
 const ECE_WEBPUSH_AES128GCM_IKM_INFO_LENGTH: usize = 144; // 14 (prefix len) + 65 (pub key len) * 2;

--- a/src/aesgcm.rs
+++ b/src/aesgcm.rs
@@ -15,7 +15,7 @@ use crate::{
     error::*,
 };
 
-const ECE_AESGCM_PAD_SIZE: usize = 2;
+pub(crate) const ECE_AESGCM_PAD_SIZE: usize = 2;
 
 const ECE_WEBPUSH_AESGCM_KEYPAIR_LENGTH: usize = 134; // (2 + Raw Key Length) * 2
 const ECE_WEBPUSH_AESGCM_AUTHINFO: &str = "Content-Encoding: auth\0";

--- a/src/legacy.rs
+++ b/src/legacy.rs
@@ -4,8 +4,8 @@
 
 pub use crate::aesgcm::AesGcmEncryptedBlock;
 use crate::{
-    aesgcm::AesGcmEceWebPush,
-    common::{get_random_padding_length, WebPushParams},
+    aesgcm::{AesGcmEceWebPush, ECE_AESGCM_PAD_SIZE},
+    common::WebPushParams,
     crypto::EcKeyComponents,
     error::*,
 };
@@ -28,10 +28,7 @@ pub fn encrypt_aesgcm(
     let cryptographer = crate::crypto::holder::get_cryptographer();
     let remote_key = cryptographer.import_public_key(remote_pub)?;
     let local_key_pair = cryptographer.generate_ephemeral_keypair()?;
-    let params = WebPushParams {
-        pad_length: get_random_padding_length(&data, cryptographer)?,
-        ..Default::default()
-    };
+    let params = WebPushParams::new_for_plaintext(data, ECE_AESGCM_PAD_SIZE);
     AesGcmEceWebPush::encrypt_with_keys(&*local_key_pair, &*remote_key, &remote_auth, data, params)
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,8 +17,8 @@ pub use crate::{
 };
 
 use crate::{
-    aes128gcm::Aes128GcmEceWebPush,
-    common::{get_random_padding_length, WebPushParams, ECE_WEBPUSH_AUTH_SECRET_LENGTH},
+    aes128gcm::{Aes128GcmEceWebPush, ECE_AES128GCM_PAD_SIZE},
+    common::{WebPushParams, ECE_WEBPUSH_AUTH_SECRET_LENGTH},
 };
 
 /// Generate a local ECE key pair and authentication secret.
@@ -45,10 +45,7 @@ pub fn encrypt(remote_pub: &[u8], remote_auth: &[u8], data: &[u8]) -> Result<Vec
     let cryptographer = crypto::holder::get_cryptographer();
     let remote_key = cryptographer.import_public_key(remote_pub)?;
     let local_key_pair = cryptographer.generate_ephemeral_keypair()?;
-    let params = WebPushParams {
-        pad_length: get_random_padding_length(&data, cryptographer)?,
-        ..Default::default()
-    };
+    let params = WebPushParams::new_for_plaintext(data, ECE_AES128GCM_PAD_SIZE);
     Aes128GcmEceWebPush::encrypt_with_keys(
         &*local_key_pair,
         &*remote_key,


### PR DESCRIPTION
This is one of the padding techniques suggested in the RFC, and while
we can't choose a default scheme that will work well for all applications,
this one at least seems easier to reason about.

Fixes #54.