### PR TITLE
chore: Dependency updates for Sept 2022

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.vscode
 /target
 **/*.rs.bk
 Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "ece"
-version = "2.2.0"
+version = "2.3.0"
 authors = ["Firefox Sync Team <sync-team@mozilla.com>", "JR Conlin <src+git@jrconlin.com>"]
 license = "MPL-2.0"
-edition = "2018"
+edition = "2021"
 repository = "https://github.com/mozilla/rust-ece"
 description = "Encrypted Content-Encoding for HTTP Rust implementation."
 keywords = ["http-ece", "web-push"]

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -30,7 +30,7 @@ pub trait LocalKeyPair: Send + Sync + 'static {
     fn as_any(&self) -> &dyn Any;
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(
     feature = "serializable-keys",
     derive(serde::Serialize, serde::Deserialize)
@@ -45,7 +45,7 @@ impl Default for EcCurve {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(
     feature = "serializable-keys",
     derive(serde::Serialize, serde::Deserialize)


### PR DESCRIPTION
Minor dependency updates for Sept 2022.

Includes switching to 2021 edition