### PR TITLE
chore: Update for March 2025

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ece"
-version = "2.3.1"
+version = "2.4.1"
 authors = [
     "Firefox Sync Team <sync-team@mozilla.com>",
     "JR Conlin <src+git@jrconlin.com>",
@@ -13,12 +13,12 @@ keywords = ["http-ece", "web-push"]
 
 [dependencies]
 byteorder = "1.3"
-thiserror = "1.0"
+thiserror = "2.0"
 base64 = "0.22"
 hex = "0.4"
 hkdf = { version = "0.12", optional = true }
-lazy_static = { version = "1.4", optional = true }
-once_cell = "1.4"
+lazy_static = { version = "1.5", optional = true }
+once_cell = "1.21"
 openssl = { version = "0.10", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 sha2 = { version = "0.10", optional = true }

--- a/src/aes128gcm.rs
+++ b/src/aes128gcm.rs
@@ -439,7 +439,7 @@ struct PlaintextRecordIterator<'a> {
     sequence_number: usize,
 }
 
-impl<'a> PlaintextRecordIterator<'a> {
+impl PlaintextRecordIterator<'_> {
     pub(crate) fn total_ciphertext_size(&self) -> usize {
         self.total_size + self.num_records * ECE_TAG_LENGTH
     }

--- a/src/aesgcm.rs
+++ b/src/aesgcm.rs
@@ -48,7 +48,7 @@ pub struct AesGcmEncryptedBlock {
 
 impl AesGcmEncryptedBlock {
     fn aesgcm_rs(rs: u32) -> u32 {
-        if rs > u32::max_value() - ECE_TAG_LENGTH as u32 {
+        if rs > u32::MAX - ECE_TAG_LENGTH as u32 {
             return 0;
         }
         rs + ECE_TAG_LENGTH as u32


### PR DESCRIPTION
Dependency updates for this quarter.

**Note**: This does not yet update to edition 2024.