### PR TITLE
Moved Key extraction that was only used in tests

### DIFF
--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -6,8 +6,11 @@ use crate::error::*;
 use std::any::Any;
 
 pub(crate) mod holder;
-#[cfg(feature = "backend-openssl")]
+#[cfg(all(not(test), feature = "backend-openssl"))]
 mod openssl;
+
+#[cfg(all(test, feature = "backend-openssl"))]
+pub mod openssl;
 
 #[cfg(not(feature = "backend-openssl"))]
 pub use holder::{set_boxed_cryptographer, set_cryptographer};
@@ -24,8 +27,6 @@ pub trait LocalKeyPair: Send + Sync + 'static {
     /// Export the public key component in the
     /// binary uncompressed point representation.
     fn pub_as_raw(&self) -> Result<Vec<u8>>;
-    /// Export the raw components of the keypair.
-    fn raw_components(&self) -> Result<EcKeyComponents>;
     /// For downcasting purposes.
     fn as_any(&self) -> &dyn Any;
 }

--- a/src/crypto/openssl.rs
+++ b/src/crypto/openssl.rs
@@ -94,6 +94,15 @@ impl OpenSSLLocalKeyPair {
             ec_key: private_key,
         })
     }
+
+    #[cfg(test)]
+    pub fn raw_components(&self) -> Result<EcKeyComponents> {
+        let private_key = self.ec_key.private_key();
+        Ok(EcKeyComponents::new(
+            private_key.to_vec(),
+            self.pub_as_raw()?,
+        ))
+    }
 }
 
 impl LocalKeyPair for OpenSSLLocalKeyPair {
@@ -105,14 +114,6 @@ impl LocalKeyPair for OpenSSLLocalKeyPair {
         let uncompressed =
             pub_key_point.to_bytes(&GROUP_P256, PointConversionForm::UNCOMPRESSED, &mut bn_ctx)?;
         Ok(uncompressed)
-    }
-
-    fn raw_components(&self) -> Result<EcKeyComponents> {
-        let private_key = self.ec_key.private_key();
-        Ok(EcKeyComponents::new(
-            private_key.to_vec(),
-            self.pub_as_raw()?,
-        ))
     }
 
     fn as_any(&self) -> &dyn Any {

--- a/src/legacy.rs
+++ b/src/legacy.rs
@@ -50,6 +50,7 @@ pub fn decrypt_aesgcm(
 #[cfg(all(test, feature = "backend-openssl"))]
 mod aesgcm_tests {
     use super::*;
+    use crate::crypto::openssl::OpenSSLLocalKeyPair;
     use base64::Engine;
     use hex;
 
@@ -152,7 +153,15 @@ mod aesgcm_tests {
         let (local_key, auth) = crate::generate_keypair_and_auth_secret()?;
         let plaintext = b"There was a little ship that had never sailed";
         let encoded = encrypt_aesgcm(&local_key.pub_as_raw()?, &auth, plaintext).unwrap();
-        let decoded = decrypt_aesgcm(&local_key.raw_components()?, &auth, &encoded)?;
+        let decoded = decrypt_aesgcm(
+            &local_key
+                .as_any()
+                .downcast_ref::<OpenSSLLocalKeyPair>()
+                .unwrap()
+                .raw_components()?,
+            &auth,
+            &encoded,
+        )?;
         assert_eq!(decoded, plaintext.to_vec());
         Ok(())
     }


### PR DESCRIPTION
While attempting to add an additional backend (rustls/ring), I had difficulties with the `LocalKeyPair::raw_components` function.

Ring does not like you to extract the private key out of a Key pair.

Considering that this function was (as far as I am aware) not part of the public API, but only used internally, I have decided to create this PR that moves it out of the trait implementation and into the OpenSSL specific impl block.

Due to the nature of scoping, and of where the tests are positioned, this also leads to an suboptimal `mod` structure in `crypto/mod.rs`.
If you know of a more idiomatic way to get the include situation sorted, feel free to let me know/edit the PR.

Thank you to all the maintainers!